### PR TITLE
Implement Passive Recon (WHOIS, DNS, crt.sh, etc.)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/r4j3sh-com/triksha
 
 go 1.24.2
+
+require (
+	github.com/likexian/gokit v0.25.15 // indirect
+	github.com/likexian/whois v1.15.6 // indirect
+	github.com/likexian/whois-parser v1.24.20 // indirect
+	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/likexian/gokit v0.25.15 h1:QjospM1eXhdMMHwZRpMKKAHY/Wig9wgcREmLtf9NslY=
+github.com/likexian/gokit v0.25.15/go.mod h1:S2QisdsxLEHWeD/XI0QMVeggp+jbxYqUxMvSBil7MRg=
+github.com/likexian/whois v1.15.6 h1:hizngFHJTNQDlhwhU+FEGyPGxy8bRnf25gHDNrSB4Ag=
+github.com/likexian/whois v1.15.6/go.mod h1:vx3kt3sZ4mx4XFgpaNp3GXQCZQIzAoyrUAkRtJwoM2I=
+github.com/likexian/whois-parser v1.24.20 h1:oxEkRi0GxgqWQRLDMJpXU1EhgWmLmkqEFZ2ChXTeQLE=
+github.com/likexian/whois-parser v1.24.20/go.mod h1:rAtaofg2luol09H+ogDzGIfcG8ig1NtM5R16uQADDz4=
+golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
+golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=

--- a/modules/passive.go
+++ b/modules/passive.go
@@ -1,22 +1,148 @@
 package modules
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
 
+	"github.com/likexian/whois"
+	whoisparser "github.com/likexian/whois-parser"
 	"github.com/r4j3sh-com/triksha/core"
 )
+
+// PassiveReconResult holds results from passive module
+type PassiveReconResult struct {
+	Whois        map[string]interface{} `json:"whois"`
+	DNSRecords   map[string][]string    `json:"dns_records"`
+	CrtshEntries []string               `json:"crtsh_entries"`
+}
 
 type PassiveModule struct{}
 
 func (m *PassiveModule) Name() string { return "passive" }
 
 func (m *PassiveModule) Run(target string, ctx *core.Context) (core.Result, error) {
+	result := PassiveReconResult{
+		Whois:        make(map[string]interface{}),
+		DNSRecords:   make(map[string][]string),
+		CrtshEntries: []string{},
+	}
 	fmt.Printf("[passive] Running passive recon for: %s\n", target)
-	// TODO: Implement passive recon (whois, DNS, etc.)
+
+	// 1. WHOIS Lookup
+	whoisRaw, err := whois.Whois(target)
+	if err == nil {
+		parsedWhois, err := whoisparser.Parse(whoisRaw)
+		if err == nil {
+			data, _ := json.Marshal(parsedWhois)
+			json.Unmarshal(data, &result.Whois) // flatten for easy printing
+		} else {
+			result.Whois["raw"] = whoisRaw
+		}
+	} else {
+		result.Whois["error"] = err.Error()
+	}
+
+	// 2. DNS Records (A, MX, NS)
+	for _, recordType := range []string{"A", "NS", "MX"} {
+		records, err := lookupDNS(target, recordType)
+		if err == nil {
+			result.DNSRecords[recordType] = records
+		}
+	}
+
+	// 3. crt.sh (subdomains by certificate transparency logs)
+	entries, err := fetchCRTshEntries(target)
+	if err == nil {
+		result.CrtshEntries = entries
+	}
+
 	return core.Result{
 		ModuleName: m.Name(),
-		Data:       map[string]interface{}{"info": "passive recon not yet implemented"},
+		Data: map[string]interface{}{
+			"whois":         result.Whois,
+			"dns_records":   result.DNSRecords,
+			"crtsh_entries": result.CrtshEntries,
+		},
 	}, nil
+}
+
+func lookupDNS(domain string, recordType string) ([]string, error) {
+	switch recordType {
+	case "A":
+		ips, err := net.LookupIP(domain)
+		if err != nil {
+			return nil, err
+		}
+		var results []string
+		for _, ip := range ips {
+			results = append(results, ip.String())
+		}
+		return results, nil
+	case "NS":
+		nss, err := net.LookupNS(domain)
+		if err != nil {
+			return nil, err
+		}
+		var results []string
+		for _, ns := range nss {
+			results = append(results, ns.Host)
+		}
+		return results, nil
+	case "MX":
+		mxs, err := net.LookupMX(domain)
+		if err != nil {
+			return nil, err
+		}
+		var results []string
+		for _, mx := range mxs {
+			results = append(results, fmt.Sprintf("%s (%d)", mx.Host, mx.Pref))
+		}
+		return results, nil
+	default:
+		return nil, fmt.Errorf("unsupported DNS type")
+	}
+}
+
+// fetchCRTshEntries scrapes crt.sh for subdomains
+func fetchCRTshEntries(domain string) ([]string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	url := "https://crt.sh/?q=%25." + domain + "&output=json"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "TrikshaReconBot/1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var entries []map[string]interface{}
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, err
+	}
+	unique := map[string]bool{}
+	var subdomains []string
+	for _, entry := range entries {
+		nameValue, ok := entry["name_value"].(string)
+		if !ok {
+			continue
+		}
+		for _, sub := range strings.Split(nameValue, "\n") {
+			sub = strings.TrimSpace(sub)
+			if !unique[sub] && sub != "" && strings.HasSuffix(sub, domain) {
+				unique[sub] = true
+				subdomains = append(subdomains, sub)
+			}
+		}
+	}
+	return subdomains, nil
 }
 
 var Passive core.Module = &PassiveModule{}


### PR DESCRIPTION
The passive module is the first layer of reconnaissance - no direct contact with the target except via third-party APIs.
	We have added:
	•	WHOIS lookup (using Go’s net package or a library)
	•	crt.sh lookup for subdomains (simple HTTP request + parse)
	•	DNS records (A, NS, MX) using Go standard library
	•	Kept it modular, clean, and ready for extension.