### PR TITLE
Implement Reporting/Export Module

### DIFF
--- a/cmd/triksha.go
+++ b/cmd/triksha.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/r4j3sh-com/triksha/core"
 	"github.com/r4j3sh-com/triksha/modules"
+	"github.com/r4j3sh-com/triksha/output"
 )
 
 func main() {
@@ -15,6 +16,9 @@ func main() {
 	targetFlag := flag.String("target", "", "Target domain or IP to scan (required)")
 	configFlag := flag.String("config", "", "Path to JSON config file (optional)")
 	modulesFlag := flag.String("modules", "", "Comma-separated list of modules to run (optional)")
+	jsonOut := flag.String("json", "", "Path to export JSON report")
+	mdOut := flag.String("md", "", "Path to export Markdown report")
+	htmlOut := flag.String("html", "", "Path to export HTML report")
 	flag.Parse()
 
 	var cfg core.Config
@@ -88,6 +92,27 @@ func main() {
 		}
 		fmt.Printf("Result [%s]: %+v\n", action.ModuleName, result.Data)
 		history = append(history, result)
+		if *jsonOut != "" {
+			if err := output.WriteJSONReport(history, *jsonOut); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to write JSON: %v\n", err)
+			} else {
+				fmt.Println("JSON report exported to", *jsonOut)
+			}
+		}
+		if *mdOut != "" {
+			if err := output.WriteMarkdownReport(history, *mdOut); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to write Markdown: %v\n", err)
+			} else {
+				fmt.Println("Markdown report exported to", *mdOut)
+			}
+		}
+		if *htmlOut != "" {
+			if err := output.WriteHTMLReport(history, *htmlOut); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to write HTML: %v\n", err)
+			} else {
+				fmt.Println("HTML report exported to", *htmlOut)
+			}
+		}
 	}
 }
 

--- a/output/html.go
+++ b/output/html.go
@@ -1,0 +1,23 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/r4j3sh-com/triksha/core"
+)
+
+func WriteHTMLReport(results []core.Result, path string) error {
+	var sb strings.Builder
+	sb.WriteString("<!DOCTYPE html><html><head><meta charset='utf-8'><title>Triksha Recon Report</title></head><body>")
+	sb.WriteString("<h1>Triksha Recon Report</h1>")
+	for _, r := range results {
+		sb.WriteString(fmt.Sprintf("<h2>Module: %s</h2>", r.ModuleName))
+		for k, v := range r.Data {
+			sb.WriteString(fmt.Sprintf("<strong>%s:</strong><pre>%v</pre>", k, v))
+		}
+	}
+	sb.WriteString("</body></html>")
+	return os.WriteFile(path, []byte(sb.String()), 0644)
+}

--- a/output/json.go
+++ b/output/json.go
@@ -1,0 +1,16 @@
+package output
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/r4j3sh-com/triksha/core"
+)
+
+func WriteJSONReport(results []core.Result, path string) error {
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -1,0 +1,24 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/r4j3sh-com/triksha/core"
+)
+
+func WriteMarkdownReport(results []core.Result, path string) error {
+	var sb strings.Builder
+	sb.WriteString("# Triksha Recon Report\n\n")
+	for _, r := range results {
+		sb.WriteString(fmt.Sprintf("## Module: %s\n\n", r.ModuleName))
+		for k, v := range r.Data {
+			sb.WriteString(fmt.Sprintf("**%s:**\n", k))
+			sb.WriteString("```\n")
+			sb.WriteString(fmt.Sprintf("%v\n", v))
+			sb.WriteString("```\n\n")
+		}
+	}
+	return os.WriteFile(path, []byte(sb.String()), 0644)
+}


### PR DESCRIPTION
Export recon results to JSON (for automation, data reuse)
Export to Markdown (for easy GitHub/Notion pasting)
Export to HTML (for client reports; simple but effective)