### PR TITLE
Add Concurrency and Reporting Polish

### DIFF
--- a/modules/report.go
+++ b/modules/report.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/r4j3sh-com/triksha/core"
 )
@@ -11,11 +12,76 @@ type ReportModule struct{}
 func (m *ReportModule) Name() string { return "report" }
 
 func (m *ReportModule) Run(target string, ctx *core.Context) (core.Result, error) {
-	fmt.Printf("[report] Generating report for: %s\n", target)
-	// TODO: Implement reporting and aggregation
+	fmt.Printf("[report] Generating summary report for: %s\n", target)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# Triksha Recon Report for %s\n\n", target))
+
+	// 1. Open Ports
+	if p, ok := ctx.Store["portscan.open_ports"]; ok {
+		sb.WriteString("## Open Ports\n")
+		if openPorts, ok := p.([]interface{}); ok && len(openPorts) > 0 {
+			for _, portInfo := range openPorts {
+				if m, ok := portInfo.(map[string]interface{}); ok {
+					sb.WriteString(fmt.Sprintf("- %v (banner: %s)\n", m["port"], m["banner"]))
+				}
+			}
+		} else {
+			sb.WriteString("No open ports found.\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// 2. Web Technologies
+	if t, ok := ctx.Store["webenum.tech_detected"]; ok {
+		sb.WriteString("## Web Technologies Detected\n")
+		if techs, ok := t.([]string); ok && len(techs) > 0 {
+			sb.WriteString("- " + strings.Join(techs, "\n- ") + "\n\n")
+		} else {
+			sb.WriteString("No significant web technologies found.\n\n")
+		}
+	}
+
+	// 3. Vulnerabilities
+	if v, ok := ctx.Store["vulnscan.vulns"]; ok {
+		sb.WriteString("## Vulnerabilities & Findings\n")
+		if vulns, ok := v.([]string); ok && len(vulns) > 0 {
+			for _, vuln := range vulns {
+				sb.WriteString(fmt.Sprintf("- %s\n", vuln))
+			}
+		} else {
+			sb.WriteString("No vulnerabilities detected by automated checks.\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// 4. Sensitive Endpoints
+	if d, ok := ctx.Store["webenum.dirs_found"]; ok {
+		sb.WriteString("## Sensitive Endpoints Discovered\n")
+		if dirs, ok := d.([]interface{}); ok && len(dirs) > 0 {
+			for _, dir := range dirs {
+				if dr, ok := dir.(map[string]interface{}); ok {
+					path := dr["path"]
+					code := dr["status_code"]
+					sb.WriteString(fmt.Sprintf("- %v (HTTP %v)\n", path, code))
+				}
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// 5. Recommendations
+	sb.WriteString("## Recommendations\n")
+	sb.WriteString("- Review all findings and consider manual validation.\n")
+	sb.WriteString("- Run specialized vulnerability scanners for detected techs (e.g., WPScan for WordPress).\n")
+	sb.WriteString("- Harden exposed services and remove or secure sensitive endpoints.\n")
+	sb.WriteString("- Follow best practices for patching, configuration, and least privilege.\n")
+
 	return core.Result{
 		ModuleName: m.Name(),
-		Data:       map[string]interface{}{"info": "report module not yet implemented"},
+		Data: map[string]interface{}{
+			"summary": sb.String(),
+		},
 	}, nil
 }
 

--- a/output/html.go
+++ b/output/html.go
@@ -1,22 +1,113 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
+	"html"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/r4j3sh-com/triksha/core"
 )
 
-func WriteHTMLReport(results []core.Result, path string) error {
+func WriteHTMLReport(cfg core.Config, results []core.Result, path string) error {
 	var sb strings.Builder
-	sb.WriteString("<!DOCTYPE html><html><head><meta charset='utf-8'><title>Triksha Recon Report</title></head><body>")
-	sb.WriteString("<h1>Triksha Recon Report</h1>")
+
+	// --- Summary Section ---
+	var summaryOpenPorts []int
+	var summaryTechs []string
+	var summaryVulns []string
+
 	for _, r := range results {
-		sb.WriteString(fmt.Sprintf("<h2>Module: %s</h2>", r.ModuleName))
-		for k, v := range r.Data {
-			sb.WriteString(fmt.Sprintf("<strong>%s:</strong><pre>%v</pre>", k, v))
+		switch r.ModuleName {
+		case "portscan":
+			if data, ok := r.Data["open_ports"]; ok {
+				if ports, ok := data.([]interface{}); ok {
+					for _, p := range ports {
+						if portInfo, ok := p.(map[string]interface{}); ok {
+							if port, ok := portInfo["port"].(float64); ok {
+								summaryOpenPorts = append(summaryOpenPorts, int(port))
+							}
+						}
+					}
+				}
+			}
+		case "webenum":
+			if data, ok := r.Data["tech_detected"].([]string); ok {
+				summaryTechs = append(summaryTechs, data...)
+			}
+		case "vulnscan":
+			if data, ok := r.Data["vulns"].([]string); ok {
+				summaryVulns = append(summaryVulns, data...)
+			}
 		}
+	}
+
+	// Deduplicate and sort for clean output
+	techMap := make(map[string]bool)
+	uniqueTechs := []string{}
+	for _, tech := range summaryTechs {
+		if !techMap[tech] {
+			techMap[tech] = true
+			uniqueTechs = append(uniqueTechs, tech)
+		}
+	}
+	sort.Strings(uniqueTechs)
+	sort.Ints(summaryOpenPorts)
+
+	// --- HTML Structure ---
+	sb.WriteString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Triksha Recon Report</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 1000px; margin: 20px auto; padding: 0 20px; }
+        h1, h2, h3 { color: #2c3e50; }
+        h1 { text-align: center; border-bottom: 2px solid #ecf0f1; padding-bottom: 10px; }
+        .summary, .module { border: 1px solid #ddd; border-radius: 8px; padding: 20px; margin-bottom: 25px; background: #f9f9f9; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+		.summary h2, .module h2 { margin-top: 0; }
+        pre { background: #2d2d2d; color: #f1f1f1; padding: 15px; border-radius: 5px; white-space: pre-wrap; word-wrap: break-word; font-family: "Fira Code", "Courier New", monospace; }
+        ul { list-style-type: square; padding-left: 20px; }
+		code { background: #ecf0f1; padding: 2px 5px; border-radius: 4px; color: #c0392b; }
+    </style>
+</head>
+<body>`)
+	sb.WriteString("<h1>Triksha Recon Report</h1>")
+
+	// Summary Box
+	sb.WriteString(`<div class="summary"><h2>Summary</h2><ul>`)
+	sb.WriteString(fmt.Sprintf("<li><strong>Target:</strong> <code>%s</code></li>", html.EscapeString(cfg.Target)))
+	if len(summaryOpenPorts) > 0 {
+		sb.WriteString(fmt.Sprintf("<li><strong>Open Ports:</strong> %v</li>", summaryOpenPorts))
+	}
+	if len(uniqueTechs) > 0 {
+		sb.WriteString(fmt.Sprintf("<li><strong>Tech Detected:</strong> %v</li>", uniqueTechs))
+	}
+	if len(summaryVulns) > 0 {
+		sb.WriteString("<li><strong>Potential Vulnerabilities:</strong><ul>")
+		for _, v := range summaryVulns {
+			sb.WriteString(fmt.Sprintf("<li>%s</li>", html.EscapeString(v)))
+		}
+		sb.WriteString("</ul></li>")
+	}
+	sb.WriteString("</ul></div>")
+
+	// Detailed Results
+	for _, r := range results {
+		sb.WriteString(fmt.Sprintf(`<div class="module"><h2>Module: %s</h2>`, html.EscapeString(r.ModuleName)))
+		for k, v := range r.Data {
+			sb.WriteString(fmt.Sprintf("<h3>%s</h3>", html.EscapeString(strings.ToTitle(k))))
+			pretty, err := json.MarshalIndent(v, "", "  ")
+			if err != nil {
+				sb.WriteString(fmt.Sprintf("<pre>%s</pre>", html.EscapeString(fmt.Sprintf("%v", v))))
+			} else {
+				sb.WriteString(fmt.Sprintf("<pre>%s</pre>", html.EscapeString(string(pretty))))
+			}
+		}
+		sb.WriteString("</div>")
 	}
 	sb.WriteString("</body></html>")
 	return os.WriteFile(path, []byte(sb.String()), 0644)

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -1,22 +1,90 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/r4j3sh-com/triksha/core"
 )
 
-func WriteMarkdownReport(results []core.Result, path string) error {
+func WriteMarkdownReport(cfg core.Config, results []core.Result, path string) error {
 	var sb strings.Builder
+
+	// --- Summary Section ---
+	var summaryOpenPorts []int
+	var summaryTechs []string
+	var summaryVulns []string
+
+	for _, r := range results {
+		switch r.ModuleName {
+		case "portscan":
+			if data, ok := r.Data["open_ports"]; ok {
+				if ports, ok := data.([]interface{}); ok {
+					for _, p := range ports {
+						if portInfo, ok := p.(map[string]interface{}); ok {
+							if port, ok := portInfo["port"].(float64); ok { // JSON unmarshals numbers to float64
+								summaryOpenPorts = append(summaryOpenPorts, int(port))
+							}
+						}
+					}
+				}
+			}
+		case "webenum":
+			if data, ok := r.Data["tech_detected"].([]string); ok {
+				summaryTechs = append(summaryTechs, data...)
+			}
+		case "vulnscan":
+			if data, ok := r.Data["vulns"].([]string); ok {
+				summaryVulns = append(summaryVulns, data...)
+			}
+		}
+	}
+
+	// Deduplicate and sort for clean output
+	techMap := make(map[string]bool)
+	uniqueTechs := []string{}
+	for _, tech := range summaryTechs {
+		if !techMap[tech] {
+			techMap[tech] = true
+			uniqueTechs = append(uniqueTechs, tech)
+		}
+	}
+	sort.Strings(uniqueTechs)
+	sort.Ints(summaryOpenPorts)
+
 	sb.WriteString("# Triksha Recon Report\n\n")
+	sb.WriteString("## Summary\n\n")
+	sb.WriteString(fmt.Sprintf("- **Target:** `%s`\n", cfg.Target))
+	if len(summaryOpenPorts) > 0 {
+		sb.WriteString(fmt.Sprintf("- **Open Ports:** %v\n", summaryOpenPorts))
+	}
+	if len(uniqueTechs) > 0 {
+		sb.WriteString(fmt.Sprintf("- **Tech Detected:** %v\n", uniqueTechs))
+	}
+	if len(summaryVulns) > 0 {
+		sb.WriteString("- **Potential Vulnerabilities:**\n")
+		for _, v := range summaryVulns {
+			sb.WriteString(fmt.Sprintf("  - %s\n", v))
+		}
+	}
+	sb.WriteString("\n---\n\n")
+
+	// --- Detailed Results ---
 	for _, r := range results {
 		sb.WriteString(fmt.Sprintf("## Module: %s\n\n", r.ModuleName))
 		for k, v := range r.Data {
-			sb.WriteString(fmt.Sprintf("**%s:**\n", k))
-			sb.WriteString("```\n")
-			sb.WriteString(fmt.Sprintf("%v\n", v))
+			sb.WriteString(fmt.Sprintf("### %s\n\n", strings.ToTitle(k)))
+			sb.WriteString("```json\n")
+			// Pretty print JSON
+			pretty, err := json.MarshalIndent(v, "", "  ")
+			if err != nil {
+				sb.WriteString(fmt.Sprintf("%v\n", v)) // fallback to default print
+			} else {
+				sb.WriteString(string(pretty) + "\n")
+			}
 			sb.WriteString("```\n\n")
 		}
 	}


### PR DESCRIPTION
Many recon steps (e.g., subdomain brute-force, portscan, passive lookup) don’t depend on each other and can run in parallel.
Saves time—massively speeds up real-world scans!
When a user runs the report module, Triksha will generate:
	•	A summary of all findings (ports, techs, vulns, sensitive endpoints, etc.)
	•	Optional severity/priority/risk ratings
	•	Recommendations (“Next steps”, “Remediation”, “Further testing”, etc.)
	•	Output can go to stdout, saved to ctx.Store, or written to a special summary file.